### PR TITLE
Update path to `doc.html`

### DIFF
--- a/hoover/search/ui.py
+++ b/hoover/search/ui.py
@@ -32,7 +32,7 @@ def file(request, filename):
     return create_response(resolve(filename))
 
 def doc_html(request, data):
-    with resolve('doc/index.html').open('rt', encoding='utf-8') as f:
+    with resolve('doc.html').open('rt', encoding='utf-8') as f:
         html = f.read()
 
     data_json = escapejs(json.dumps(data))


### PR DESCRIPTION
Somehow, between hoover-ui `v0.2.2` and `v0.2.3`, the path
`doc/index.html` changed to `doc.html`, probably because of an updated
nodejs dependency. Hopefully it won't randomly change back.